### PR TITLE
Fix Title component test assertion

### DIFF
--- a/src/components/Title/indexTitle.cy.tsx
+++ b/src/components/Title/indexTitle.cy.tsx
@@ -5,7 +5,7 @@ describe("Title", () => {
   it("uses custom text for the title", () => {
     cy.mount(<Title>EXEMPLO DE TÍTULO</Title>);
     cy.get('[data-cy="titleText"]').should("exist");
-    cy.get("[data-cy=titleText]").should("contains.text", "EXEMPLO DE TÍTULO");
+    cy.get("[data-cy=titleText]").should("contain.text", "EXEMPLO DE TÍTULO");
   });
 
   it("the line exists and if it is visible", () => {


### PR DESCRIPTION
## Summary
- fix typo in assertion for the Title component test
- run Cypress component tests to ensure they pass

## Testing
- `npm ci`
- `npm run cy:run`


------
https://chatgpt.com/codex/tasks/task_e_684011a324708326bc88ee4f9cb88e66