### PR TITLE
Fix Portuguese typo about GitHub Actions

### DIFF
--- a/src/components/Sections/AboutSite/index.tsx
+++ b/src/components/Sections/AboutSite/index.tsx
@@ -100,7 +100,7 @@ export function AboutSite() {
               <strong>lint-staged</strong> antes dos commits.
             </li>
             <li>
-              <strong>Pipeline automatizada (CI/CD)</strong>, integração enter Github Actions e Vercel{" "}<br />
+              <strong>Pipeline automatizada (CI/CD)</strong>, integração entre GitHub Actions e Vercel{" "}<br />
               para deploy em ambiente de homologação e produção.
             </li>
             <li>


### PR DESCRIPTION
## Summary
- correct Portuguese phrase about GitHub Actions in AboutSite section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68401191fe8083269cbce450c4de2615