### PR TITLE
Make PortfolioItem link optional

### DIFF
--- a/src/components/Sections/Portfolio/PortfolioItem.tsx
+++ b/src/components/Sections/Portfolio/PortfolioItem.tsx
@@ -51,9 +51,18 @@ export function PortfolioItem({
     );
   });
 
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    url ? (
+      <Link href={String(url)} target="_blank" rel="noopener noreferrer">
+        {children}
+      </Link>
+    ) : (
+      <>{children}</>
+    );
+
   return (
     <div className={styles.job} ref={jobRef}>
-      <Link href={String(url)} target="_blank" rel="noopener noreferrer">
+      <Wrapper>
         <div className={styles.image}>
           <Image
             src={String(image)}
@@ -216,7 +225,7 @@ export function PortfolioItem({
         </div>
 
         <ButtonArrow />
-      </Link>
+      </Wrapper>
     </div>
   );
 }

--- a/src/components/Sections/Portfolio/index.tsx
+++ b/src/components/Sections/Portfolio/index.tsx
@@ -96,7 +96,6 @@ export function Portfolio() {
               key={index}
               image={_job.image}
               title={_job.title}
-              url={_job.url}
               technologies={_job.technologies}
             >
               <div dangerouslySetInnerHTML={{ __html: _job.text }} />

--- a/src/components/Sections/Portfolio/indexPortfolio.cy.tsx
+++ b/src/components/Sections/Portfolio/indexPortfolio.cy.tsx
@@ -1,0 +1,8 @@
+import { Portfolio } from "./index";
+
+describe("Portfolio", () => {
+  it("renders portfolio items without links", () => {
+    cy.mount(<Portfolio />);
+    cy.get(".jobs").find("a").should("not.exist");
+  });
+});

--- a/src/components/Sections/Portfolio/indexPortfolioItem.cy.tsx
+++ b/src/components/Sections/Portfolio/indexPortfolioItem.cy.tsx
@@ -1,0 +1,30 @@
+import { PortfolioItem } from "./PortfolioItem";
+
+describe("PortfolioItem", () => {
+  it("renders anchor when url prop is provided", () => {
+    cy.mount(
+      <PortfolioItem
+        image="/image/jobs/cultura-inglesa-festival.webp"
+        title="Project"
+        url="https://example.com"
+        technologies={[]}
+      >
+        <div>Content</div>
+      </PortfolioItem>
+    );
+    cy.get("a").should("have.attr", "href", "https://example.com");
+  });
+
+  it("renders without anchor when url prop is absent", () => {
+    cy.mount(
+      <PortfolioItem
+        image="/image/jobs/cultura-inglesa-festival.webp"
+        title="Project"
+        technologies={[]}
+      >
+        <div>Content</div>
+      </PortfolioItem>
+    );
+    cy.get("a").should("not.exist");
+  });
+});

--- a/src/data/jobs.json
+++ b/src/data/jobs.json
@@ -2,7 +2,6 @@
     {
         "title": "Festival Cultura Inglesa",
         "text": "<p>O maior desafio nesse projeto foi o desenvolvimento de um <strong>layout fiel</strong> ao projetado, com <strong>animações complexas</strong> e adaptáveis a qualquer tipo de tela. Todo conteúdo integrado por API Rest, cadastro, área logada, customização de perfil, integração com Vimeo, transmissões ao vivo com chats em tempo real entre muitos outros recursos.</p>",
-        "url": "https://www.culturainglesafestival.com.br/",
         "technologies": [
             "react",
             "javascript",
@@ -16,7 +15,6 @@
     {
         "title": "NIVEA Mais",
         "text": "<p>Uma plataforma para dar aos usuários o caesso a um programa de pontos integrado com as farmácias de todo país. Integração com uma <strong>API complexa</strong>, foco em <strong>usabilidade e experiência do usuário</strong> principalmente na versão para dispositivos móveis. <strong>Layout fiel</strong> ao projetado.</p>",
-        "url": "https://mais.nivea.com.br/",
         "technologies": [
             "react",
             "javascript",
@@ -28,7 +26,6 @@
     {
         "title": "Programa Mais Clientes",
         "text": "<p>Por solicitação do cliente, nesse projeto trabalhamos com <strong>PHP</strong> usando o framework Symfony, e JQuery. Sistema todo administrável com blog, integração complexa com sistema de terceiro para obtenção dos dados.</p>",
-        "url": "https://www.programamaisclientes.com.br/",
         "technologies": [
             "javascript",
             "sass"


### PR DESCRIPTION
## Summary
- make link optional in `PortfolioItem`
- drop `url` props when rendering portfolio section
- remove URLs from portfolio data
- add Cypress tests for `PortfolioItem` and `Portfolio`

## Testing
- `npm run lint`
- `npm run build`
- `npm run cy:run`


------
https://chatgpt.com/codex/tasks/task_e_6842c3955ff0832691a280850dbab44e